### PR TITLE
UPSTREAM: <carry>: Add Containerfile.art for ART builds

### DIFF
--- a/Containerfile.art
+++ b/Containerfile.art
@@ -12,7 +12,7 @@ ENV GOFLAGS=""
 
 RUN cd $SOURCE_DIR/cmd && go build -o $SOURCE_DIR/_output/cert-manager-istio-csr -ldflags '-w -s' -tags ${GO_BUILD_TAGS} main.go
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:ae09ecc3d754bc1726cbda3e2599cc7839e09fe1cc547ce173cf669b645be3cc
 
 ARG RELEASE_VERSION
 ARG COMMIT_SHA
@@ -25,6 +25,7 @@ COPY --from=builder /licenses /licenses
 USER 65534:65534
 
 LABEL com.redhat.component="cert-manager-istio-csr-container" \
+      cpe="cpe:/a:redhat:cert_manager:1.19::el9" \
       name="cert-manager/cert-manager-istio-csr-rhel9" \
       version="${RELEASE_VERSION}" \
       summary="cert-manager-istio-csr" \

--- a/Containerfile.art
+++ b/Containerfile.art
@@ -1,0 +1,43 @@
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25 AS builder
+
+ARG SOURCE_DIR="/go/src/github.com/openshift/cert-manager-istio-csr"
+
+COPY . $SOURCE_DIR
+COPY LICENSE /licenses/
+
+ENV GO_BUILD_TAGS=strictfipsruntime,openssl
+ENV GOEXPERIMENT=strictfipsruntime
+ENV CGO_ENABLED=1
+ENV GOFLAGS=""
+
+RUN cd $SOURCE_DIR/cmd && go build -o $SOURCE_DIR/_output/cert-manager-istio-csr -ldflags '-w -s' -tags ${GO_BUILD_TAGS} main.go
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+ARG RELEASE_VERSION
+ARG COMMIT_SHA
+ARG SOURCE_URL
+ARG SOURCE_DIR="/go/src/github.com/openshift/cert-manager-istio-csr"
+
+COPY --from=builder $SOURCE_DIR/_output/cert-manager-istio-csr /usr/local/bin/cert-manager-istio-csr
+COPY --from=builder /licenses /licenses
+
+USER 65534:65534
+
+LABEL com.redhat.component="cert-manager-istio-csr-container" \
+      name="cert-manager/cert-manager-istio-csr-rhel9" \
+      version="${RELEASE_VERSION}" \
+      summary="cert-manager-istio-csr" \
+      maintainer="Red Hat, Inc." \
+      description="cert-manager-istio-csr-container" \
+      vendor="Red Hat, Inc." \
+      release="${RELEASE_VERSION}" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="data,images,cert-manager-istio-csr" \
+      io.openshift.build.commit.id="${COMMIT_SHA}" \
+      io.openshift.build.source-location="${SOURCE_URL}" \
+      io.openshift.build.commit.url="${SOURCE_URL}/commit/${COMMIT_SHA}" \
+      io.k8s.display-name="cert-manager-istio-csr" \
+      io.k8s.description="cert-manager-istio-csr-container"
+
+ENTRYPOINT ["/usr/local/bin/cert-manager-istio-csr"]


### PR DESCRIPTION
## Problem Statement

ART needs to build cert-manager-istio-csr images through its Konflux-based layered products pipeline. ART builds require a dedicated Containerfile.art with ART's builder images, base images, and LABEL conventions.

## Related Issue

Part of [ART-14816](https://redhat.atlassian.net/browse/ART-14816) (Onboard OAP operators to ART).

## Proposed Changes

Add Containerfile.art adapted from cert-manager-operator-release release-1.19 for ART build pipeline (COPY . . instead of submodule, ART builder images and labels).